### PR TITLE
Undirected shuttles

### DIFF
--- a/docs/jsonDoc.md
+++ b/docs/jsonDoc.md
@@ -7,7 +7,7 @@ The JSON file contains three main objects. The first one, "_adjacency_", represe
 adjacency.1: ["5"]
 adjacency.5: ["2", "3"]
 ```
-means that node with id $1$ has an outgoing edge to node $5$, and node $5$ has two outgoing edges to nodes $2$ and $3$.
+means that node with id $1$ has an edge to node $5$, and node $5$ has two edges to nodes $2$ and $3$. Note that, since the edges are undirected, one could write `x: [y]` or `y: [x]`. It doesn't make any difference, just be sure that you don't write it in both ways at the same time (that would be repeating edges, which will throw an error).
 
 The second object, "_trap_", contains all the information related to the traps on the device. Fisrt of all, the attribute ```trap.capacity: "integer" ``` shows how many ions at the same time there can be in a trap. The attribute ``` trap.traps: []``` contains an array of objects, each one of them with information about an individual trap. Each object contains the following data, illustrated with an example:
 ```

--- a/docs/jsonDoc.md
+++ b/docs/jsonDoc.md
@@ -36,9 +36,9 @@ Finally, the last object "_shuttle_" contains the attribute ```shuttle.shuttles:
 Shuttle id:
 "id": "s1",
 
-Id of the node it goes out from:
-"from": "1",
+One of the ends of the shuttle:
+"end0": "1",
 
-Id of the node it goes to:
-"to": "5",
+The other end:
+"end1": "5",
 ```

--- a/src/initFunctions.jl
+++ b/src/initFunctions.jl
@@ -3,18 +3,22 @@ using .QCCDevDes_Types
 using .QCCDevControl_Types
 
 """
-Creates a graph using a object topologyJSON.
+Creates a graph using an object QCCDevDescription.
+Throws ArgumentError if LightGraphs fails to add a node. This will happen
+    if there are redundancies in the adjacency list (i.e. repeated edges),
+    so maybe is not worth having.
 """
-function initGraph(topology::QCCDevDescription)::SimpleDiGraph{Int64}
+function initGraph(topology::QCCDevDescription)::SimpleGraph{Int64}
     nodesAdjacency::Dict{String,Array{Int64}} = topology.adjacency.nodes
-    graphTopology::SimpleDiGraph{Int64} = DiGraph(length(nodesAdjacency))
+    graph::SimpleGraph{Int64} = SimpleGraph(length(nodesAdjacency))
 
     for nodes in keys(nodesAdjacency) 
         for node in nodesAdjacency[nodes]
-            add_edge!(graphTopology, parse(Int64, nodes), node)
+            stat = add_edge!(graph, parse(Int64, nodes), node)
+            stat || throw(ArgumentError("Failed adding edge ($nodes,$node) to graph."))
         end
     end
-    return graphTopology
+    return graph
 end
 
 """

--- a/src/qccdevcontrol.jl
+++ b/src/qccdevcontrol.jl
@@ -47,7 +47,7 @@ struct QCCDevCtrl
     traps       ::Dict{Int64,Trap}
     junctions   ::Dict{Int64,Junction}
     shuttles    ::Dict{String,Shuttle}
-    graph       ::SimpleDiGraph{Int64}
+    graph       ::SimpleGraph{Int64}
 
     # Rest of struct contains description of current status of qdev
     # and its ions, such as the list of operations that are ongoing

--- a/src/types/control.jl
+++ b/src/types/control.jl
@@ -73,17 +73,17 @@ end
 
 """  
 Struct for the shuttles.
-id: shuttle identifictor 
-from & to: direcction of shuttle and endings
-Throws ArgumentError if 'from' adn 'to' are the same
+id: shuttle ID 
+end0 & end1: ID of components they are connected to
+Throws ArgumentError if 'end0' and 'end1' are the same
 """
 struct Shuttle
     id::String
-    from::Int64
-    to::Int64
-    Shuttle(id, from, to) = from == to ? 
-            throw(ArgumentError("In shuttle ID $id \"from\" and \"to\" must be different")) : 
-            new(id, from, to)
+    end0::Int64
+    end1::Int64
+    Shuttle(id, end0, end1) = end0 == end1 ? 
+            throw(ArgumentError("In shuttle ID $id \"end0\" and \"end1\" must be different")) : 
+            new(id, end0, end1)
 end
 
 """  

--- a/src/types/description.jl
+++ b/src/types/description.jl
@@ -26,8 +26,8 @@ end
 
 struct  ShuttleInfoDesc
     id:: String
-    from:: Int64
-    to:: Int64
+    end0:: Int64
+    end1:: Int64
 end
 
 struct ShuttleDesc

--- a/test/testFiles/topology.json
+++ b/test/testFiles/topology.json
@@ -55,33 +55,33 @@
         "shuttles": [
             {
                 "id": "s1",
-                "from": 1,
-                "to": 5
+                "end0": 1,
+                "end1": 5
             },
             {
                 "id": "s2",
-                "from": 5,
-                "to": 2
+                "end0": 5,
+                "end1": 2
             },
             {
                 "id": "s3",
-                "from": 2,
-                "to": 4
+                "end0": 2,
+                "end1": 4
             },
             {
                 "id": "s4",
-                "from": 4,
-                "to": 1
+                "end0": 4,
+                "end1": 1
             },
             {
                 "id": "s5",
-                "from": 5,
-                "to": 3
+                "end0": 5,
+                "end1": 3
             },
             {
                 "id": "s6",
-                "from": 3,
-                "to": 4
+                "end0": 3,
+                "end1": 4
             }
         ]
     }

--- a/test/testFiles/wrongTopology.json
+++ b/test/testFiles/wrongTopology.json
@@ -55,33 +55,33 @@
         "shuttles": [
             {
                 "id": "s1",
-                "from": 1,
-                "to": 5
+                "end0": 1,
+                "end1": 5
             },
             {
                 "id": "s2",
-                "from": 5,
-                "to": 2
+                "end0": 5,
+                "end1": 2
             },
             {
                 "id": "s3",
-                "from": 2,
-                "to": 4
+                "end0": 2,
+                "end1": 4
             },
             {
                 "id": "s4",
-                "from": 4,
-                "to": 1
+                "end0": 4,
+                "end1": 1
             },
             {
                 "id": "s5",
-                "from": 5,
-                "to": 3
+                "end0": 5,
+                "end1": 3
             },
             {
                 "id": "s6",
-                "from": 3,
-                "to": 4
+                "end0": 3,
+                "end1": 4
             }
         ]
     }

--- a/test/tests/qccdDev.jl
+++ b/test/tests/qccdDev.jl
@@ -31,8 +31,8 @@ function checkEqualQCCD(qccd1::QCCDevDescription, qccd2::QCCDevDescription):: Bo
     @assert size(shs1) == size(shs2)
     for (sh1,sh2) in zip(shs1,shs2)
         @assert sh1.id == sh2.id
-        @assert sh1.from == sh2.from
-        @assert sh1.to == sh2.to
+        @assert sh1.end0 == sh2.end0
+        @assert sh1.end1 == sh2.end1
     end
     return true
 end
@@ -49,7 +49,7 @@ function _initJunctionsTest()
         @assert length(shuttleIds) == _typeSizes[juncType]
         for shuttleId in shuttleIds
             shuttle = filter(x -> x.id == shuttleId, shuttles)[1]
-            @assert shuttle.from == k || shuttle.to == k
+            @assert shuttle.end0 == k || shuttle.end1 == k
         end
     end
     return true


### PR DESCRIPTION
PR for making shuttles undirected.

Remove "from" and "to" attributes in shuttles:
Change attributes
Check logic for QCCDevCtrl and QCCDevDesc creation.
Check tests.
Change graph to undirected graph.
Change JSON and docs.